### PR TITLE
feat(mget): replaced mgetDoc with DocumentRef

### DIFF
--- a/document.go
+++ b/document.go
@@ -18,7 +18,7 @@ type DocumentRef struct {
 }
 
 // NewDocumentRef constructs a DocumentRef with the core two identifiers, ID and Index.
-func NewDocumentRef(id, index string) DocumentRef {
+func NewDocumentRef(index, id string) DocumentRef {
 	return DocumentRef{
 		id:    id,
 		index: index,
@@ -41,14 +41,8 @@ type DocumentResult interface {
 	GetSource() []byte
 }
 
-// PtrTo is a generic constraint that restricts value to be pointers.
-// T can be any type.
-type PtrTo[T any] interface {
-	*T
-}
-
 // ReadDocument reads the source from a DocumentResult and parses it into the passed document object.
-// Document and be any pointer type.
+// Document can be any pointer type.
 func ReadDocument[D any, P PtrTo[D], R DocumentResult](docResult R, document P) error {
 	return json.Unmarshal(docResult.GetSource(), document)
 }

--- a/document.go
+++ b/document.go
@@ -3,52 +3,52 @@ package opensearchtools
 import "encoding/json"
 
 // RoutableDoc interface defines an OpenSearch document that can be routed to a specific index.
-// The most basic implementation is DocumentID.
+// The most basic implementation is DocumentRef.
 type RoutableDoc interface {
-    // ID returns the document ID
-    ID() string
-    // Index returns the index the document should be routed to
-    Index() string
+	// ID returns the document ID
+	ID() string
+	// Index returns the index the document should be routed to
+	Index() string
 }
 
-// DocumentID is a simple implementation of RoutableDoc. Identifying a document with it's basic components.
-type DocumentID struct {
-    id    string
-    index string
+// DocumentRef references a document via its index and id. It is the most basic implementation of RoutableDoc
+type DocumentRef struct {
+	id    string
+	index string
 }
 
-// NewDocumentID constructs a DocumentID with the core two identifiers, ID and Index.
-func NewDocumentID(id, index string) DocumentID {
-    return DocumentID{
-        id:    id,
-        index: index,
-    }
+// NewDocumentRef constructs a DocumentRef with the core two identifiers, ID and Index.
+func NewDocumentRef(id, index string) DocumentRef {
+	return DocumentRef{
+		id:    id,
+		index: index,
+	}
 }
 
 // ID returns the document ID
-func (d DocumentID) ID() string {
-    return d.id
+func (d DocumentRef) ID() string {
+	return d.id
 }
 
 // Index returns the index the document should be routed to
-func (d DocumentID) Index() string {
-    return d.index
+func (d DocumentRef) Index() string {
+	return d.index
 }
 
 // DocumentResult defines any OpenSearch response that contains a document source.
 type DocumentResult interface {
-    // GetSource returns the raw bytes of the document
-    GetSource() []byte
+	// GetSource returns the raw bytes of the document
+	GetSource() []byte
 }
 
 // PtrTo is a generic constraint that restricts value to be pointers.
 // T can be any type.
 type PtrTo[T any] interface {
-    *T
+	*T
 }
 
 // ReadDocument reads the source from a DocumentResult and parses it into the passed document object.
 // Document and be any pointer type.
 func ReadDocument[D any, P PtrTo[D], R DocumentResult](docResult R, document P) error {
-    return json.Unmarshal(docResult.GetSource(), document)
+	return json.Unmarshal(docResult.GetSource(), document)
 }

--- a/document.go
+++ b/document.go
@@ -5,10 +5,10 @@ import "encoding/json"
 // RoutableDoc interface defines an OpenSearch document that can be routed to a specific index.
 // The most basic implementation is DocumentRef.
 type RoutableDoc interface {
-	// ID returns the document ID
-	ID() string
 	// Index returns the index the document should be routed to
 	Index() string
+	// ID returns the document ID
+	ID() string
 }
 
 // DocumentRef references a document via its index and id. It is the most basic implementation of RoutableDoc
@@ -25,14 +25,14 @@ func NewDocumentRef(index, id string) DocumentRef {
 	}
 }
 
-// ID returns the document ID
-func (d DocumentRef) ID() string {
-	return d.id
-}
-
 // Index returns the index the document should be routed to
 func (d DocumentRef) Index() string {
 	return d.index
+}
+
+// ID returns the document ID
+func (d DocumentRef) ID() string {
+	return d.id
 }
 
 // DocumentResult defines any OpenSearch response that contains a document source.

--- a/document.go
+++ b/document.go
@@ -13,8 +13,8 @@ type RoutableDoc interface {
 
 // DocumentRef references a document via its index and id. It is the most basic implementation of RoutableDoc
 type DocumentRef struct {
-	id    string
 	index string
+	id    string
 }
 
 // NewDocumentRef constructs a DocumentRef with the core two identifiers, ID and Index.

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,13 @@ module github.com/CrowdStrike/opensearchtools
 
 go 1.19
 
-require github.com/opensearch-project/opensearch-go/v2 v2.2.0
+require (
+	github.com/opensearch-project/opensearch-go/v2 v2.2.0
+	github.com/stretchr/testify v1.8.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,7 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/mget.go
+++ b/mget.go
@@ -1,13 +1,13 @@
 package opensearchtools
 
 import (
-    "bytes"
-    "context"
-    "encoding/json"
-    "net/http"
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
 
-    "github.com/opensearch-project/opensearch-go/v2"
-    "github.com/opensearch-project/opensearch-go/v2/opensearchapi"
+	"github.com/opensearch-project/opensearch-go/v2"
+	"github.com/opensearch-project/opensearch-go/v2/opensearchapi"
 )
 
 // MGetRequest wraps the functionality of [opensearchapi.MgetRequest] by supporting request body creation.
@@ -17,36 +17,59 @@ import (
 //	    Add("example_index", "totally_real_id").
 //	    Do(context.background(), client)
 type MGetRequest struct {
-    // Index destination for entire request
-    // if used individual documents don't need to specify the index
-    Index string `json:"-"`
+	// Index destination for entire request
+	// if used individual documents don't need to specify the index
+	Index string
 
-    // Docs are the list of documents to be fetched
-    Docs []mgetDoc `json:"docs"`
+	// Docs are the list of documents to be fetched.
+	Docs []RoutableDoc
 }
 
 // NewMGetRequest instantiates an empty MGetRequest.
 // An empty MGetRequest is executable but will return zero documents because zero have been requested.
 func NewMGetRequest() *MGetRequest {
-    return &MGetRequest{}
+	return &MGetRequest{}
 }
 
-// Add a request for a document with id at a specific index.
-// If index is an empty string, the request relies on the top level index MGetRequest.Index
+// Add a DocumentRef to the documents being requested.
+// If index is an empty string, the request relies on the top level MGetRequest.Index.
 func (m *MGetRequest) Add(index, id string) *MGetRequest {
-    m.Docs = append(m.Docs, mgetDoc{
-        ID:    id,
-        Index: index,
-    })
+	return m.AddDocs(NewDocumentRef(index, id))
+}
 
-    return m
+// AddDocs - add any number RoutableDoc to the documents being requested.
+// If the doc does not return anything for [RoutableDoc.Index], the request relies on the top level MGetRequest.Index.
+func (m *MGetRequest) AddDocs(docs ...RoutableDoc) *MGetRequest {
+	m.Docs = append(m.Docs, docs...)
+	return m
 }
 
 // SetIndex sets the top level index for the request. If a individual document request does not have an index specified,
 // this index will be used.
 func (m *MGetRequest) SetIndex(index string) *MGetRequest {
-    m.Index = index
-    return m
+	m.Index = index
+	return m
+}
+
+// Source translates the MGetRequest into the shape expected by OpenSearch.
+func (m *MGetRequest) Source() any {
+	docs := make([]any, len(m.Docs))
+	for i, d := range m.Docs {
+		docReq := make(map[string]any)
+
+		if d.Index() != "" {
+			docReq["_index"] = d.Index()
+		}
+
+		docReq["_id"] = d.ID()
+
+		docs[i] = d
+	}
+
+	source := make(map[string]any)
+	source["docs"] = docs
+
+	return source
 }
 
 // Do executes the Multi-Get MGetRequest using the provided opensearch.Client.
@@ -56,64 +79,58 @@ func (m *MGetRequest) SetIndex(index string) *MGetRequest {
 //   - The request to OpenSearch fails
 //   - The results json cannot be unmarshalled
 func (m *MGetRequest) Do(ctx context.Context, client *opensearch.Client) (*MGetResponse, error) {
-    bodyBytes, jErr := json.Marshal(m)
-    if jErr != nil {
-        return nil, jErr
-    }
+	bodyBytes, jErr := json.Marshal(m.Source())
+	if jErr != nil {
+		return nil, jErr
+	}
 
-    osResp, rErr := opensearchapi.MgetRequest{
-        Index: m.Index,
-        Body:  bytes.NewReader(bodyBytes),
-    }.Do(ctx, client)
+	osResp, rErr := opensearchapi.MgetRequest{
+		Index: m.Index,
+		Body:  bytes.NewReader(bodyBytes),
+	}.Do(ctx, client)
 
-    if rErr != nil {
-        return nil, rErr
-    }
+	if rErr != nil {
+		return nil, rErr
+	}
 
-    resp := &MGetResponse{
-        StatusCode: osResp.StatusCode,
-        Header:     osResp.Header,
-    }
+	resp := &MGetResponse{
+		StatusCode: osResp.StatusCode,
+		Header:     osResp.Header,
+	}
 
-    var respBuf bytes.Buffer
-    if _, err := respBuf.ReadFrom(osResp.Body); err != nil {
-        return nil, err
-    }
+	var respBuf bytes.Buffer
+	if _, err := respBuf.ReadFrom(osResp.Body); err != nil {
+		return nil, err
+	}
 
-    if err := json.Unmarshal(respBuf.Bytes(), &resp); err != nil {
-        return nil, err
-    }
+	if err := json.Unmarshal(respBuf.Bytes(), &resp); err != nil {
+		return nil, err
+	}
 
-    return resp, nil
+	return resp, nil
 }
 
-// mgetDoc is a simple struct representing an individual document to be fetched in a MultiGet request
-type mgetDoc struct {
-    ID    string `json:"_id,omitempty"`
-    Index string `json:"_index,omitempty"`
-}
-
-// MGetResponse wraps the functionality of [opensearchapi.Response] by unmarshalling the reponse body into a
-// slice of MGetResults
+// MGetResponse wraps the functionality of [opensearchapi.Response] by unmarshalling the response body into a
+// slice of MGetResults.
 type MGetResponse struct {
-    StatusCode int          `json:"-"`
-    Header     http.Header  `json:"-"`
-    Docs       []MGetResult `json:"docs,omitempty"`
+	StatusCode int          `json:"-"`
+	Header     http.Header  `json:"-"`
+	Docs       []MGetResult `json:"docs,omitempty"`
 }
 
-// MGetResult is the individual result for each requested item
+// MGetResult is the individual result for each requested item.
 type MGetResult struct {
-    Index       string          `json:"_index,omitempty"`
-    ID          string          `json:"_id,omitempty"`
-    Version     int             `json:"_version,omitempty"`
-    SeqNo       int             `json:"_seq_no,omitempty"`
-    PrimaryTerm int             `json:"_primary_term,omitempty"`
-    Found       bool            `json:"found,omitempty"`
-    Source      json.RawMessage `json:"_source,omitempty"`
-    Error       error           `json:"-"`
+	Index       string          `json:"_index,omitempty"`
+	ID          string          `json:"_id,omitempty"`
+	Version     int             `json:"_version,omitempty"`
+	SeqNo       int             `json:"_seq_no,omitempty"`
+	PrimaryTerm int             `json:"_primary_term,omitempty"`
+	Found       bool            `json:"found,omitempty"`
+	Source      json.RawMessage `json:"_source,omitempty"`
+	Error       error           `json:"-"`
 }
 
-// GetSource returns the raw bytes of the document of the MGetResult
+// GetSource returns the raw bytes of the document of the MGetResult.
 func (m MGetResult) GetSource() []byte {
-    return []byte(m.Source)
+	return []byte(m.Source)
 }

--- a/mget.go
+++ b/mget.go
@@ -52,7 +52,7 @@ func (m *MGetRequest) SetIndex(index string) *MGetRequest {
 }
 
 // Source translates the MGetRequest into the shape expected by OpenSearch.
-func (m *MGetRequest) Source() any {
+func (m *MGetRequest) Source() map[string]any {
 	docs := make([]any, len(m.Docs))
 	for i, d := range m.Docs {
 		docReq := make(map[string]any)

--- a/mget_test.go
+++ b/mget_test.go
@@ -1,0 +1,304 @@
+package opensearchtools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testIndex1 = "test_index"
+	testIndex2 = "test_index2"
+
+	testID1 = "test_id"
+	testID2 = "test_id2"
+)
+
+type testDoc struct {
+	id, index string
+}
+
+func (d testDoc) ID() string {
+	return d.id
+}
+
+func (d testDoc) Index() string {
+	return d.index
+}
+
+func TestMGetRequest_Add(t *testing.T) {
+	type args struct {
+		index string
+		id    string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *MGetRequest
+	}{
+		{
+			name: "add simple test",
+			args: args{
+				index: testIndex1,
+				id:    testID1,
+			},
+			want: &MGetRequest{
+				Docs: []RoutableDoc{
+					DocumentRef{
+						index: testIndex1,
+						id:    testID1,
+					},
+				},
+			},
+		},
+		{
+			name: "add without index",
+			args: args{
+				id: testID1,
+			},
+			want: &MGetRequest{
+				Docs: []RoutableDoc{
+					DocumentRef{
+						id: testID1,
+					},
+				},
+			},
+		},
+		{
+			name: "add without id",
+			args: args{
+				index: testIndex1,
+			},
+			want: &MGetRequest{
+				Docs: []RoutableDoc{
+					DocumentRef{
+						index: testIndex1,
+					},
+				},
+			},
+		},
+		{
+			name: "add empty string",
+			args: args{
+				index: "",
+				id:    "",
+			},
+			want: &MGetRequest{
+				Docs: []RoutableDoc{
+					DocumentRef{
+						index: "",
+						id:    "",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewMGetRequest().Add(tt.args.index, tt.args.id)
+			require.Len(t, m.Docs, 1, "MGetRequest.Add should only add a single document request")
+			wantDoc := tt.want.Docs[0]
+			gotDoc := m.Docs[0]
+
+			require.Equal(t, wantDoc.ID(), gotDoc.ID(), "incorrect document ID after Add")
+			require.Equal(t, wantDoc.Index(), gotDoc.Index(), "incorrect document Index after Add")
+		})
+	}
+}
+
+func TestMGetRequest_AddDocs(t *testing.T) {
+	// Expected id and index from the RoutableDocs on the MGetRequest
+	type mockDoc struct {
+		id, index string
+	}
+
+	tests := []struct {
+		name string
+		docs []RoutableDoc
+		want []mockDoc
+	}{
+		{
+			name: "Single doc of single type",
+			docs: []RoutableDoc{
+				NewDocumentRef(testIndex1, testID1),
+			},
+			want: []mockDoc{
+				{id: testID1, index: testIndex1},
+			},
+		},
+		{
+			name: "Multiple docs of single type",
+			docs: []RoutableDoc{
+				NewDocumentRef(testIndex1, testID1),
+				NewDocumentRef(testIndex2, testID2),
+			},
+			want: []mockDoc{
+				{id: testID1, index: testIndex1},
+				{id: testID2, index: testIndex2},
+			},
+		},
+		{
+			name: "Multiple docs of mixed types",
+			docs: []RoutableDoc{
+				NewDocumentRef(testIndex1, testID1),
+				testDoc{id: testID2, index: testIndex2},
+			},
+			want: []mockDoc{
+				{id: testID1, index: testIndex1},
+				{id: testID2, index: testIndex2},
+			},
+		},
+		{
+			name: "Single document, no index",
+			docs: []RoutableDoc{
+				NewDocumentRef("", testID1),
+			},
+			want: []mockDoc{
+				{id: testID1, index: ""},
+			},
+		},
+		{
+			name: "Single document, no ID",
+			docs: []RoutableDoc{
+				NewDocumentRef(testIndex1, ""),
+			},
+			want: []mockDoc{
+				{id: "", index: testIndex1},
+			},
+		},
+		{
+			name: "Single document, no ID or Index",
+			docs: []RoutableDoc{
+				NewDocumentRef("", ""),
+			},
+			want: []mockDoc{
+				{id: "", index: ""},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewMGetRequest().AddDocs(tt.docs...)
+
+			require.Len(t, m.Docs, len(tt.want), "unexpected number of documents added to the request")
+
+			for i, gotDoc := range m.Docs {
+				wantDoc := tt.want[i]
+
+				require.Equal(t, wantDoc.id, gotDoc.ID())
+				require.Equal(t, wantDoc.index, gotDoc.Index())
+			}
+		})
+	}
+}
+
+func TestMGetRequest_MarshalJSON(t *testing.T) {
+	type fields struct {
+		Index string
+		Docs  []RoutableDoc
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name: "Empty Request",
+			fields: fields{
+				Index: "",
+				Docs:  []RoutableDoc{},
+			},
+			want:    []byte(`{"docs":[]}`),
+			wantErr: false,
+		},
+		{
+			name: "Single document single type",
+			fields: fields{
+				Docs: []RoutableDoc{
+					testDoc{id: testID1, index: testIndex1},
+				},
+			},
+			want:    []byte(`{"docs":[{"_id":"test_id","_index":"test_index"}]}`),
+			wantErr: false,
+		},
+		{
+			name: "Multiple documents single type",
+			fields: fields{
+				Docs: []RoutableDoc{
+					testDoc{id: testID1, index: testIndex1},
+					testDoc{id: testID2, index: testIndex2},
+				},
+			},
+			want:    []byte(`{"docs":[{"_id":"test_id","_index":"test_index"},{"_id":"test_id2","_index":"test_index2"}]}`),
+			wantErr: false,
+		},
+		{
+			name: "Multiple documents mixed type",
+			fields: fields{
+				Docs: []RoutableDoc{
+					testDoc{id: testID1, index: testIndex1},
+					NewDocumentRef(testIndex2, testID2),
+				},
+			},
+			want:    []byte(`{"docs":[{"_id":"test_id","_index":"test_index"},{"_id":"test_id2","_index":"test_index2"}]}`),
+			wantErr: false,
+		},
+		{
+			name: "Document without index",
+			fields: fields{
+				Docs: []RoutableDoc{
+					testDoc{id: testID1},
+				},
+			},
+			want:    []byte(`{"docs":[{"_id":"test_id"}]}`),
+			wantErr: false,
+		},
+		{
+			name: "Document without id",
+			fields: fields{
+				Docs: []RoutableDoc{
+					testDoc{index: testIndex1},
+				},
+			},
+			want:    []byte(`{"docs":[{"_id":"","_index":"test_index"}]}`),
+			wantErr: false,
+		},
+		{
+			name: "Document without id and index",
+			fields: fields{
+				Docs: []RoutableDoc{
+					testDoc{},
+				},
+			},
+			want:    []byte(`{"docs":[{"_id":""}]}`),
+			wantErr: false,
+		},
+		{
+			name: "Request level index does not affect request json body",
+			fields: fields{
+				Index: testIndex2,
+				Docs: []RoutableDoc{
+					testDoc{id: testID1, index: testIndex1},
+				},
+			},
+			want:    []byte(`{"docs":[{"_id":"test_id","_index":"test_index"}]}`),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &MGetRequest{
+				Index: tt.fields.Index,
+				Docs:  tt.fields.Docs,
+			}
+			got, err := m.MarshalJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			require.Equalf(t, tt.want, got, "expected %s - got %s", tt.want, got)
+		})
+	}
+}

--- a/mget_test.go
+++ b/mget_test.go
@@ -14,16 +14,16 @@ const (
 	testID2 = "test_id2"
 )
 
-type testDoc struct {
-	id, index string
+type mgetTestDoc struct {
+	index, id string
 }
 
-func (d testDoc) ID() string {
-	return d.id
-}
-
-func (d testDoc) Index() string {
+func (d mgetTestDoc) Index() string {
 	return d.index
+}
+
+func (d mgetTestDoc) ID() string {
+	return d.id
 }
 
 func TestMGetRequest_Add(t *testing.T) {
@@ -141,7 +141,7 @@ func TestMGetRequest_AddDocs(t *testing.T) {
 			name: "Multiple docs of mixed types",
 			docs: []RoutableDoc{
 				NewDocumentRef(testIndex1, testID1),
-				testDoc{id: testID2, index: testIndex2},
+				mgetTestDoc{id: testID2, index: testIndex2},
 			},
 			want: []mockDoc{
 				{id: testID1, index: testIndex1},
@@ -216,7 +216,7 @@ func TestMGetRequest_MarshalJSON(t *testing.T) {
 			name: "Single document single type",
 			fields: fields{
 				Docs: []RoutableDoc{
-					testDoc{id: testID1, index: testIndex1},
+					mgetTestDoc{id: testID1, index: testIndex1},
 				},
 			},
 			want:    []byte(`{"docs":[{"_id":"test_id","_index":"test_index"}]}`),
@@ -226,8 +226,8 @@ func TestMGetRequest_MarshalJSON(t *testing.T) {
 			name: "Multiple documents single type",
 			fields: fields{
 				Docs: []RoutableDoc{
-					testDoc{id: testID1, index: testIndex1},
-					testDoc{id: testID2, index: testIndex2},
+					mgetTestDoc{id: testID1, index: testIndex1},
+					mgetTestDoc{id: testID2, index: testIndex2},
 				},
 			},
 			want:    []byte(`{"docs":[{"_id":"test_id","_index":"test_index"},{"_id":"test_id2","_index":"test_index2"}]}`),
@@ -237,7 +237,7 @@ func TestMGetRequest_MarshalJSON(t *testing.T) {
 			name: "Multiple documents mixed type",
 			fields: fields{
 				Docs: []RoutableDoc{
-					testDoc{id: testID1, index: testIndex1},
+					mgetTestDoc{id: testID1, index: testIndex1},
 					NewDocumentRef(testIndex2, testID2),
 				},
 			},
@@ -248,7 +248,7 @@ func TestMGetRequest_MarshalJSON(t *testing.T) {
 			name: "Document without index",
 			fields: fields{
 				Docs: []RoutableDoc{
-					testDoc{id: testID1},
+					mgetTestDoc{id: testID1},
 				},
 			},
 			want:    []byte(`{"docs":[{"_id":"test_id"}]}`),
@@ -258,7 +258,7 @@ func TestMGetRequest_MarshalJSON(t *testing.T) {
 			name: "Document without id",
 			fields: fields{
 				Docs: []RoutableDoc{
-					testDoc{index: testIndex1},
+					mgetTestDoc{index: testIndex1},
 				},
 			},
 			want:    []byte(`{"docs":[{"_id":"","_index":"test_index"}]}`),
@@ -268,7 +268,7 @@ func TestMGetRequest_MarshalJSON(t *testing.T) {
 			name: "Document without id and index",
 			fields: fields{
 				Docs: []RoutableDoc{
-					testDoc{},
+					mgetTestDoc{},
 				},
 			},
 			want:    []byte(`{"docs":[{"_id":""}]}`),
@@ -279,7 +279,7 @@ func TestMGetRequest_MarshalJSON(t *testing.T) {
 			fields: fields{
 				Index: testIndex2,
 				Docs: []RoutableDoc{
-					testDoc{id: testID1, index: testIndex1},
+					mgetTestDoc{id: testID1, index: testIndex1},
 				},
 			},
 			want:    []byte(`{"docs":[{"_id":"test_id","_index":"test_index"}]}`),
@@ -298,7 +298,7 @@ func TestMGetRequest_MarshalJSON(t *testing.T) {
 				return
 			}
 
-			require.Equalf(t, tt.want, got, "expected %s - got %s", tt.want, got)
+			require.JSONEq(t, string(tt.want), string(got))
 		})
 	}
 }

--- a/pointer_constraint.go
+++ b/pointer_constraint.go
@@ -1,0 +1,7 @@
+package opensearchtools
+
+// PtrTo is a generic constraint that restricts value to be pointers.
+// T can be any type.
+type PtrTo[T any] interface {
+	*T
+}


### PR DESCRIPTION
Renamed DocumentID to a more apt DocumentRef as it references a document in a specific location. Once doing that, it made sense to use it for the MGetRequest instead of the unexperted mgetDoc.

This change also lets users to submit their own implementation of RoutableDoc if they are leveraging it.

Incidentally also fixed some tabbing, did not realize gofmt defaults to tab character, but my ide was formatting with spaces.