### PR TITLE
Do test before lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: lint-and-test
+name: Test & Lint
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  lint-test-and-build:
+  test-and-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -16,10 +16,10 @@ jobs:
         with:
           go-version: 1.19
 
+      - name: test
+        run: go test -v -race ./...
+
       - name: lint
         uses: golangci/golangci-lint-action@v3.3.1
         with:
           github-token: ${{ github.token }}
-
-      - name: test
-        run: go test -v -race ./...


### PR DESCRIPTION
Because lint will fail with an un-helpful error message if test is failing due to untidy go.sum.