### PR TITLE
chore(search): refactored query interface function Source

### DIFF
--- a/search/boolean_query_test.go
+++ b/search/boolean_query_test.go
@@ -1,0 +1,83 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoolQuery_ToOpenSearchJSON(t *testing.T) {
+	basicQuery := NewTermQuery("field", "value")
+
+	tests := []struct {
+		name    string
+		query   *BoolQuery
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Empty Bool Query",
+			query:   NewBoolQuery(),
+			want:    `{"bool":{}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Bool query must with single query",
+			query:   NewBoolQuery().Must(basicQuery),
+			want:    `{"bool":{"must":[{"term":{"field":"value"}}]}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Bool query must not with single query",
+			query:   NewBoolQuery().MustNot(NewTermQuery("field", "value")),
+			want:    `{"bool":{"must_not":[{"term":{"field":"value"}}]}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Bool query should with single query",
+			query:   NewBoolQuery().Should(NewTermQuery("field", "value")),
+			want:    `{"bool":{"should":[{"term":{"field":"value"}}]}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Bool query filter with single query",
+			query:   NewBoolQuery().Filter(NewTermQuery("field", "value")),
+			want:    `{"bool":{"filter":[{"term":{"field":"value"}}]}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Bool query with minimum should match",
+			query:   NewBoolQuery().MinimumShouldMatch(1),
+			want:    `{"bool":{"minimum_should_match":1}}`,
+			wantErr: false,
+		},
+		{
+			name: "Bool query with everything",
+			query: NewBoolQuery().
+				Must(basicQuery).
+				MustNot(basicQuery).
+				Should(basicQuery).
+				Filter(basicQuery).
+				MinimumShouldMatch(1),
+			want:    `{"bool":{"minimum_should_match":1,"must":[{"term":{"field":"value"}}],"must_not":[{"term":{"field":"value"}}],"should":[{"term":{"field":"value"}}],"filter":[{"term":{"field":"value"}}]}}`, //nolint:lll
+			wantErr: false,
+		},
+		{
+			name:    "Bool query with multiple sub queries",
+			query:   NewBoolQuery().Must(basicQuery, basicQuery),
+			want:    `{"bool":{"must":[{"term":{"field":"value"}},{"term":{"field":"value"}}]}}`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.query.ToOpenSearchJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToOpenSearchJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			require.JSONEq(t, tt.want, string(got))
+		})
+	}
+}

--- a/search/exists_query.go
+++ b/search/exists_query.go
@@ -1,5 +1,7 @@
 package search
 
+import "encoding/json"
+
 // ExistsQuery searches for documents that contain a specific field.
 //
 // For more details see https://opensearch.org/docs/latest/opensearch/query-dsl/term/#exists
@@ -8,17 +10,18 @@ type ExistsQuery struct {
 }
 
 // NewExistsQuery instantiates an exists query.
+// An empty field value will be rejected by OpenSearch
 func NewExistsQuery(field string) *ExistsQuery {
 	return &ExistsQuery{field: field}
 }
 
-// Source converts the ExistsQuery to the correct OpenSearch JSON.
-func (q *ExistsQuery) Source() (any, error) {
-	eq := make(map[string]any)
-	eq["field"] = q.field
+// ToOpenSearchJSON converts the ExistsQuery to the correct OpenSearch JSON.
+func (q *ExistsQuery) ToOpenSearchJSON() ([]byte, error) {
+	source := map[string]any{
+		"exists": map[string]any{
+			"field": q.field,
+		},
+	}
 
-	source := make(map[string]any)
-	source["exists"] = eq
-
-	return source, nil
+	return json.Marshal(source)
 }

--- a/search/exists_query_test.go
+++ b/search/exists_query_test.go
@@ -1,0 +1,40 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExistsQuery_ToOpenSearchJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   *ExistsQuery
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "empty exists query",
+			query:   &ExistsQuery{},
+			want:    `{"exists":{"field":""}}`,
+			wantErr: false,
+		},
+		{
+			name:    "simple exists query",
+			query:   NewExistsQuery("field"),
+			want:    `{"exists":{"field":"field"}}`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.query.ToOpenSearchJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToOpenSearchJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			require.JSONEq(t, tt.want, string(got))
+		})
+	}
+}

--- a/search/match_all_query.go
+++ b/search/match_all_query.go
@@ -1,5 +1,7 @@
 package search
 
+import "encoding/json"
+
 // MatchAllQuery returns all documents.
 //
 // For more details see https://opensearch.org/docs/latest/opensearch/query-dsl/full-text/#match-all
@@ -11,10 +13,11 @@ func NewMatchAllQuery() *MatchAllQuery {
 	return &MatchAllQuery{}
 }
 
-// Source converts the MatchAllQuery to the correct OpenSearch JSON.
-func (q *MatchAllQuery) Source() (any, error) {
-	source := make(map[string]any)
-	source["match_all"] = struct{}{}
+// ToOpenSearchJSON converts the MatchAllQuery to the correct OpenSearch JSON.
+func (q *MatchAllQuery) ToOpenSearchJSON() ([]byte, error) {
+	source := map[string]any{
+		"match_all": struct{}{},
+	}
 
-	return source, nil
+	return json.Marshal(source)
 }

--- a/search/match_all_query_test.go
+++ b/search/match_all_query_test.go
@@ -1,0 +1,35 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchAllQuery_ToOpenSearchJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   *MatchAllQuery
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Basic Constructor",
+			query:   NewMatchAllQuery(),
+			want:    `{"match_all":{}}`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.query.ToOpenSearchJSON()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToOpenSearchJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			require.JSONEq(t, tt.want, string(got))
+		})
+	}
+}

--- a/search/match_phrase_query.go
+++ b/search/match_phrase_query.go
@@ -1,6 +1,12 @@
 package search
 
+import "encoding/json"
+
 // MatchPhraseQuery finds document that match documents that contain an exact phrase in a specified order.
+// An empty MatchPhraseQuery will be rejected by OpenSearch for two reasons:
+//
+//   - a field must not be empty or null
+//   - a value must be non-null
 //
 // For more details see https://opensearch.org/docs/latest/opensearch/query-dsl/full-text/#match-phrase
 type MatchPhraseQuery struct {
@@ -16,13 +22,13 @@ func NewMatchPhraseQuery(field, phrase string) *MatchPhraseQuery {
 	}
 }
 
-// Source converts the MatchPhraseQuery to the correct OpenSearch JSON.
-func (q *MatchPhraseQuery) Source() (any, error) {
-	mq := make(map[string]any)
-	mq[q.field] = q.phrase
+// ToOpenSearchJSON converts the MatchPhraseQuery to the correct OpenSearch JSON.
+func (q *MatchPhraseQuery) ToOpenSearchJSON() ([]byte, error) {
+	source := map[string]any{
+		"match_phrase": map[string]any{
+			q.field: q.phrase,
+		},
+	}
 
-	source := make(map[string]any)
-	source["match_phrase"] = mq
-
-	return source, nil
+	return json.Marshal(source)
 }

--- a/search/match_phrase_query_test.go
+++ b/search/match_phrase_query_test.go
@@ -1,0 +1,47 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchPhraseQuery_ToOpenSearchJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   *MatchPhraseQuery
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Empty query",
+			query:   &MatchPhraseQuery{},
+			want:    `{"match_phrase":{"":""}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Simple Success",
+			query:   NewMatchPhraseQuery("field", "phrase"),
+			want:    `{"match_phrase":{"field":"phrase"}}`,
+			wantErr: false,
+		},
+		{
+			name:    "No phrase",
+			query:   NewMatchPhraseQuery("field", ""),
+			want:    `{"match_phrase":{"field":""}}`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.query.ToOpenSearchJSON()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToOpenSearchJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			require.JSONEq(t, tt.want, string(got))
+		})
+	}
+}

--- a/search/match_query.go
+++ b/search/match_query.go
@@ -1,5 +1,7 @@
 package search
 
+import "encoding/json"
+
 // MatchQuery finds documents that matches the analyzed string value.
 //
 // For more details see https://opensearch.org/docs/latest/opensearch/query-dsl/full-text/#match
@@ -18,24 +20,23 @@ func NewMatchQuery(field, value string) *MatchQuery {
 	}
 }
 
-// Operator sets the operator to use when using a boolean query.
+// SetOperator sets the operator to use when using a boolean query.
 // Can be "AND" or "OR" (default).
-func (q *MatchQuery) Operator(op string) *MatchQuery {
+func (q *MatchQuery) SetOperator(op string) *MatchQuery {
 	q.operator = op
 	return q
 }
 
-// Source converts the MatchQuery to the correct OpenSearch JSON.
-func (q *MatchQuery) Source() (any, error) {
-	mq := make(map[string]any)
-	mq["query"] = q.value
-	mq["operator"] = q.operator
+// ToOpenSearchJSON converts the MatchQuery to the correct OpenSearch JSON.
+func (q *MatchQuery) ToOpenSearchJSON() ([]byte, error) {
+	source := map[string]any{
+		"match": map[string]any{
+			q.field: map[string]any{
+				"query":    q.value,
+				"operator": q.operator,
+			},
+		},
+	}
 
-	search := make(map[string]any)
-	search[q.field] = mq
-
-	source := make(map[string]any)
-	source["match"] = search
-
-	return source, nil
+	return json.Marshal(source)
 }

--- a/search/match_query_test.go
+++ b/search/match_query_test.go
@@ -1,0 +1,53 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchQuery_ToOpenSearchJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   *MatchQuery
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Empty Query",
+			query:   &MatchQuery{},
+			want:    `{"match":{"":{"query":"","operator":""}}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Simple Success",
+			query:   NewMatchQuery("field", "value"),
+			want:    `{"match":{"field":{"query":"value","operator":"or"}}}`,
+			wantErr: false,
+		},
+		{
+			name:    "No value",
+			query:   NewMatchQuery("field", ""),
+			want:    `{"match":{"field":{"query":"","operator":"or"}}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Different operator",
+			query:   NewMatchQuery("field", "value").SetOperator("and"),
+			want:    `{"match":{"field":{"query":"value","operator":"and"}}}`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.query.ToOpenSearchJSON()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToOpenSearchJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			require.JSONEq(t, tt.want, string(got))
+		})
+	}
+}

--- a/search/prefix_query.go
+++ b/search/prefix_query.go
@@ -1,6 +1,12 @@
 package search
 
+import "encoding/json"
+
 // PrefixQuery finds documents that contain the value as a prefix.
+// An empty PrefixQuery will be rejected by OpenSearch for two reasons:
+//
+//   - a field must not be empty or null
+//   - a value must be non-null
 //
 // For more details see https://opensearch.org/docs/latest/opensearch/query-dsl/term/#prefix
 type PrefixQuery struct {
@@ -9,17 +15,17 @@ type PrefixQuery struct {
 }
 
 // NewPrefixQuery initializes a PrefixQuery targeting field looking for the prefix of value.
-func NewPrefixQuery(name string, value any) *PrefixQuery {
-	return &PrefixQuery{field: name, value: value}
+func NewPrefixQuery(field string, value any) *PrefixQuery {
+	return &PrefixQuery{field: field, value: value}
 }
 
-// Source converts the PrefixQuery Source converts the MatchPhraseQuery to the correct OpenSearch JSON.
-func (q *PrefixQuery) Source() (any, error) {
-	source := make(map[string]any)
-	pq := make(map[string]any)
-	source["prefix"] = pq
+// ToOpenSearchJSON converts the PrefixQuery Source converts the MatchPhraseQuery to the correct OpenSearch JSON.
+func (q *PrefixQuery) ToOpenSearchJSON() ([]byte, error) {
+	source := map[string]any{
+		"prefix": map[string]any{
+			q.field: q.value,
+		},
+	}
 
-	pq[q.field] = q.value
-
-	return source, nil
+	return json.Marshal(source)
 }

--- a/search/prefix_query_test.go
+++ b/search/prefix_query_test.go
@@ -1,0 +1,47 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrefixQuery_ToOpenSearchJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   *PrefixQuery
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Empty Query",
+			query:   &PrefixQuery{},
+			want:    `{"prefix":{"":null}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Simple Success",
+			query:   NewPrefixQuery("field", "value"),
+			want:    `{"prefix":{"field":"value"}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Empty Value",
+			query:   NewPrefixQuery("field", ""),
+			want:    `{"prefix":{"field":""}}`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.query.ToOpenSearchJSON()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToOpenSearchJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			require.JSONEq(t, tt.want, string(got))
+		})
+	}
+}

--- a/search/query.go
+++ b/search/query.go
@@ -3,6 +3,6 @@ package search
 // Query wraps all query types in a common interface. Facilitating a common pattern to convert the logical
 // struct into the appropriate request JSON.
 type Query interface {
-	// Source returns the JSON-serializable query request
-	Source() (any, error)
+	// ToOpenSearchJSON converts the Query struct to the expected OpenSearch JSON
+	ToOpenSearchJSON() ([]byte, error)
 }

--- a/search/range_query_test.go
+++ b/search/range_query_test.go
@@ -1,0 +1,75 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRangeQuery_ToOpenSearchJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   *RangeQuery
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Empty Query",
+			query:   &RangeQuery{},
+			want:    `{"range":{"":{}}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Basic Constructor",
+			query:   NewRangeQuery("field"),
+			want:    `{"range":{"field":{}}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Less than",
+			query:   NewRangeQuery("field").Lt("value"),
+			want:    `{"range":{"field":{"lt":"value"}}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Less than or equal to",
+			query:   NewRangeQuery("field").Lte("value"),
+			want:    `{"range":{"field":{"lte":"value"}}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Greater than",
+			query:   NewRangeQuery("field").Gt("value"),
+			want:    `{"range":{"field":{"gt":"value"}}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Greater than or equal to",
+			query:   NewRangeQuery("field").Gte("value"),
+			want:    `{"range":{"field":{"gte":"value"}}}`,
+			wantErr: false,
+		},
+		{
+			name: "All fields set",
+			query: NewRangeQuery("field").
+				Lt("value").
+				Lte("value").
+				Gt("value").
+				Gte("value"),
+			want:    `{"range":{"field":{"lt":"value","lte":"value","gt":"value","gte":"value"}}}`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.query.ToOpenSearchJSON()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToOpenSearchJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			require.JSONEq(t, tt.want, string(got))
+		})
+	}
+}

--- a/search/regex_query.go
+++ b/search/regex_query.go
@@ -1,6 +1,12 @@
 package search
 
+import "encoding/json"
+
 // RegexQuery allows you to search on a targeted field matching on values that fit the regular expression.
+// An empty Regex will be rejected by OpenSearch for two reasons:
+//
+//   - a field must not be empty or null
+//   - a value must be non-null
 //
 // For more details see https://opensearch.org/docs/latest/opensearch/query-dsl/term/#regex
 type RegexQuery struct {
@@ -16,13 +22,13 @@ func NewRegexQuery(field, regex string) *RegexQuery {
 	}
 }
 
-// Source converts the RegexQuery to the correct OpenSearch JSON.
-func (q *RegexQuery) Source() (any, error) {
-	rq := make(map[string]any)
-	rq[q.field] = q.regex
+// ToOpenSearchJSON converts the RegexQuery to the correct OpenSearch JSON.
+func (q *RegexQuery) ToOpenSearchJSON() ([]byte, error) {
+	source := map[string]any{
+		"regexp": map[string]any{
+			q.field: q.regex,
+		},
+	}
 
-	source := make(map[string]any)
-	source["regexp"] = rq
-
-	return source, nil
+	return json.Marshal(source)
 }

--- a/search/regex_query_test.go
+++ b/search/regex_query_test.go
@@ -1,0 +1,41 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegexQuery_ToOpenSearchJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   *RegexQuery
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Empty Query",
+			query:   &RegexQuery{},
+			want:    `{"regexp":{"":""}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Basic Constructor",
+			query:   NewRegexQuery("field", "^value$"),
+			want:    `{"regexp":{"field":"^value$"}}`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.query.ToOpenSearchJSON()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToOpenSearchJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			require.JSONEq(t, tt.want, string(got))
+		})
+	}
+}

--- a/search/sort.go
+++ b/search/sort.go
@@ -1,6 +1,9 @@
 package search
 
-// Sort encapsulates the sort capabilities for OpenSearch
+import "encoding/json"
+
+// Sort encapsulates the sort capabilities for OpenSearch.
+// An empty Sort will be rejected by OpenSearch as a field must be non-null and non-empty.
 //
 // For more details see https://opensearch.org/docs/latest/opensearch/search/sort/
 type Sort struct {
@@ -16,8 +19,8 @@ func NewSort(field string, desc bool) *Sort {
 	}
 }
 
-// Source converts the Sort to the correct OpenSearch JSON.
-func (s *Sort) Source() any {
+// ToOpenSearchJSON converts the Sort to the correct OpenSearch JSON.
+func (s *Sort) ToOpenSearchJSON() ([]byte, error) {
 	sort := make(map[string]any)
 	if s.Desc {
 		sort["order"] = "desc"
@@ -25,8 +28,9 @@ func (s *Sort) Source() any {
 		sort["order"] = "asc"
 	}
 
-	source := make(map[string]any)
-	source[s.Field] = sort
+	source := map[string]any{
+		s.Field: sort,
+	}
 
-	return source
+	return json.Marshal(source)
 }

--- a/search/sort_test.go
+++ b/search/sort_test.go
@@ -1,0 +1,47 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSort_ToOpenSearchJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		sort    *Sort
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Empty sort",
+			sort:    &Sort{},
+			want:    `{"":{"order":"asc"}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Sort descending",
+			sort:    NewSort("field", true),
+			want:    `{"field":{"order":"desc"}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Sort ascending",
+			sort:    NewSort("field", false),
+			want:    `{"field":{"order":"asc"}}`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.sort.ToOpenSearchJSON()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToOpenSearchJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			require.JSONEq(t, tt.want, string(got))
+		})
+	}
+}

--- a/search/term_query.go
+++ b/search/term_query.go
@@ -1,9 +1,16 @@
 package search
 
+import "encoding/json"
+
 // TermQuery finds documents that have the field matching the exact value.
+// An empty TermQuery will be rejected by OpenSearch for two reasons:
+//
+//   - a field must not be empty or null
+//   - a value must be non-null
 //
 // For more details see https://opensearch.org/docs/latest/opensearch/query-dsl/term/
 type TermQuery struct {
+	//TODO: given the above empty constraints, should we validate on the client library?
 	field string
 	value any
 }
@@ -13,13 +20,13 @@ func NewTermQuery(field string, value any) *TermQuery {
 	return &TermQuery{field: field, value: value}
 }
 
-// Source converts the TermQuery to the correct OpenSearch JSON.
-func (q *TermQuery) Source() (any, error) {
-	source := make(map[string]any)
-	tq := make(map[string]any)
-	source["term"] = tq
+// ToOpenSearchJSON converts the TermQuery to the correct OpenSearch JSON.
+func (q *TermQuery) ToOpenSearchJSON() ([]byte, error) {
+	source := map[string]any{
+		"term": map[string]any{
+			q.field: q.value,
+		},
+	}
 
-	tq[q.field] = q.value
-
-	return source, nil
+	return json.Marshal(source)
 }

--- a/search/term_query_test.go
+++ b/search/term_query_test.go
@@ -1,0 +1,53 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTermQuery_ToOpenSearchJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   *TermQuery
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Empty Query",
+			query:   &TermQuery{},
+			want:    `{"term":{"":null}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Simple Success",
+			query:   NewTermQuery("field", "value"),
+			want:    `{"term":{"field":"value"}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Search for empty value",
+			query:   NewTermQuery("field", ""),
+			want:    `{"term":{"field":""}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Search for empty field and value",
+			query:   NewTermQuery("", ""),
+			want:    `{"term":{"":""}}`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.query.ToOpenSearchJSON()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToOpenSearchJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			require.JSONEq(t, tt.want, string(got))
+		})
+	}
+}

--- a/search/terms_query.go
+++ b/search/terms_query.go
@@ -1,6 +1,12 @@
 package search
 
+import "encoding/json"
+
 // TermsQuery finds documents that have the field match one of the listed values.
+// An empty TermsQuery will be rejected by OpenSearch for two reasons:
+//
+//   - a field must not be empty or null
+//   - a value must be non-null
 //
 // For more details see https://opensearch.org/docs/latest/opensearch/query-dsl/term/#terms
 type TermsQuery struct {
@@ -16,13 +22,13 @@ func NewTermsQuery(field string, values ...any) *TermsQuery {
 	}
 }
 
-// Source converts the TermsQuery to the correct OpenSearch JSON.
-func (q *TermsQuery) Source() (any, error) {
-	tq := make(map[string]any)
-	tq[q.field] = q.values
+// ToOpenSearchJSON converts the TermsQuery to the correct OpenSearch JSON.
+func (q *TermsQuery) ToOpenSearchJSON() ([]byte, error) {
+	source := map[string]any{
+		"terms": map[string]any{
+			q.field: q.values,
+		},
+	}
 
-	source := make(map[string]any)
-	source["terms"] = tq
-
-	return source, nil
+	return json.Marshal(source)
 }

--- a/search/terms_query_test.go
+++ b/search/terms_query_test.go
@@ -1,0 +1,59 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTermsQuery_ToOpenSearchJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   *TermsQuery
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Empty query",
+			query:   &TermsQuery{},
+			want:    `{"terms":{"":null}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Basic Constructor",
+			query:   NewTermsQuery("field"),
+			want:    `{"terms":{"field":null}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Single value",
+			query:   NewTermsQuery("field", "value1"),
+			want:    `{"terms":{"field":["value1"]}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Multiple Values",
+			query:   NewTermsQuery("field", "value1", "value2", "value3"),
+			want:    `{"terms":{"field":["value1","value2","value3"]}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Mixed type values",
+			query:   NewTermsQuery("field", "value1", 2),
+			want:    `{"terms":{"field":["value1",2]}}`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.query.ToOpenSearchJSON()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToOpenSearchJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			require.JSONEq(t, tt.want, string(got))
+		})
+	}
+}

--- a/search/wildcard_query.go
+++ b/search/wildcard_query.go
@@ -1,6 +1,12 @@
 package search
 
+import "encoding/json"
+
 // WildcardQuery searches for documents with a field matching a wildcard pattern.
+// An empty TermQuery will be rejected by OpenSearch for two reasons:
+//
+//   - a field must not be empty or null
+//   - a value must be non-null
 //
 // For more details see https://opensearch.org/docs/latest/opensearch/query-dsl/term/#wildcards
 type WildcardQuery struct {
@@ -13,13 +19,13 @@ func NewWildcardQuery(field, value string) *WildcardQuery {
 	return &WildcardQuery{field: field, value: value}
 }
 
-// Source converts the WildcardQuery to the correct OpenSearch JSON.
-func (q *WildcardQuery) Source() (any, error) {
-	eq := make(map[string]any)
-	eq[q.field] = q.value
+// ToOpenSearchJSON converts the WildcardQuery to the correct OpenSearch JSON.
+func (q *WildcardQuery) ToOpenSearchJSON() ([]byte, error) {
+	source := map[string]any{
+		"wildcard": map[string]any{
+			q.field: q.value,
+		},
+	}
 
-	source := make(map[string]any)
-	source["wildcard"] = eq
-
-	return source, nil
+	return json.Marshal(source)
 }

--- a/search/wildcard_query_test.go
+++ b/search/wildcard_query_test.go
@@ -1,0 +1,47 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWildcardQuery_ToOpenSearchJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   *WildcardQuery
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Empty Query",
+			query:   &WildcardQuery{},
+			want:    `{"wildcard":{"":""}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Simple Success",
+			query:   NewWildcardQuery("field", "value"),
+			want:    `{"wildcard":{"field":"value"}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Search for empty value",
+			query:   NewWildcardQuery("field", ""),
+			want:    `{"wildcard":{"field":""}}`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.query.ToOpenSearchJSON()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToOpenSearchJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			require.JSONEq(t, tt.want, string(got))
+		})
+	}
+}

--- a/search_test.go
+++ b/search_test.go
@@ -1,0 +1,81 @@
+package opensearchtools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/CrowdStrike/opensearchtools/search"
+)
+
+func TestSearchRequest_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		search  *SearchRequest
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Basic Constructor",
+			search:  NewSearchRequest(),
+			want:    `{}`,
+			wantErr: false,
+		},
+		{
+			name: "All Fields",
+			search: NewSearchRequest().
+				SetQuery(search.NewTermQuery("field", "value")).
+				AddIndices("test_index").
+				AddSort(search.NewSort("field", true)).
+				SetSize(1),
+			want:    `{"query":{"term":{"field":"value"}},"sort":[{"field":{"order":"desc"}}],"size":1}`,
+			wantErr: false,
+		},
+		{
+			name: "Set Query",
+			search: NewSearchRequest().
+				SetQuery(search.NewTermQuery("field", "value")),
+			want:    `{"query":{"term":{"field":"value"}}}`,
+			wantErr: false,
+		},
+		{
+			name: "Set Index", // Query param so no effect on JSON
+			search: NewSearchRequest().
+				AddIndices("test_index"),
+			want:    `{}`,
+			wantErr: false,
+		},
+		{
+			name: "Single Sort",
+			search: NewSearchRequest().
+				AddSort(search.NewSort("field", true)),
+			want:    `{"sort":[{"field":{"order":"desc"}}]}`,
+			wantErr: false,
+		},
+		{
+			name: "Multi sort",
+			search: NewSearchRequest().
+				AddSort(search.NewSort("field", true), search.NewSort("field2", false)),
+			want:    `{"sort":[{"field":{"order":"desc"}},{"field2":{"order":"asc"}}]}`,
+			wantErr: false,
+		},
+		{
+			name: "Set Size",
+			search: NewSearchRequest().
+				SetSize(1),
+			want:    `{"size":1}`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.search.MarshalJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			require.JSONEq(t, tt.want, string(got))
+		})
+	}
+}


### PR DESCRIPTION
This change renames, and refactors, the generic method Source, into a more explicit method ToOpenSearch.

This change is also applied to the Sort struct.

Additionally, the Source method on the SearchRequest was replaced with MarshalJSON to implement the json.Marshaler interface