### PR TITLE
fix(bulk): change BulkRequest.MarshalJSON -> ToOpenSearchJSON

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -43,8 +43,12 @@ func (r *BulkRequest) WithIndex(index string) *BulkRequest {
 	return r
 }
 
-// MarshalJSON marshals the BulkRequest into the JSON format expected by OpenSearch
-func (r *BulkRequest) MarshalJSON() ([]byte, error) {
+// ToOpenSearchJSON marshals the BulkRequest into the JSON format expected by OpenSearch.
+// Note: A BulkRequest is multi-line json with new line delimiters. It is not a singular valid json struct.
+//
+// { action1 json }
+// { action2 json }
+func (r *BulkRequest) ToOpenSearchJSON() ([]byte, error) {
 	if len(r.Actions) == 0 {
 		return nil, fmt.Errorf("bulk request requires at least one action")
 	}
@@ -73,7 +77,7 @@ func (r *BulkRequest) MarshalJSON() ([]byte, error) {
 //   - The call to OpenSearch fails
 //   - The result json cannot be unmarshalled
 func (r *BulkRequest) Do(ctx context.Context, client *opensearch.Client) (*BulkResponse, error) {
-	rawBody, jErr := json.Marshal(r)
+	rawBody, jErr := r.ToOpenSearchJSON()
 	if jErr != nil {
 		return nil, jErr
 	}

--- a/bulk_test.go
+++ b/bulk_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBulkRequest_MarshalJSON(t *testing.T) {
+func TestBulkRequest_ToOpenSearchJSON(t *testing.T) {
 	testDoc := NewDocumentRef("index", "id")
 
 	testCreateAction := NewCreateBulkAction(testDoc)
@@ -67,7 +67,7 @@ func TestBulkRequest_MarshalJSON(t *testing.T) {
 			r := NewBulkRequest()
 			r.Add(tt.actions...)
 
-			got, err := r.MarshalJSON()
+			got, err := r.ToOpenSearchJSON()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
The BulkRequest json is not actually valid json, so json.Marshal(BulkRequest) would fail. This is because it generates a multi line json body for each BulkAction. So this change removes it's implementation of MarshalJSON to match the existing pattern of using ToOpenSearchJSON instead.