### PR TITLE
A couple small cleanups

### DIFF
--- a/mget.go
+++ b/mget.go
@@ -19,7 +19,7 @@ type MGet interface {
 //   - OpenSearch 2
 //
 // This MGetRequest is intended to be used along with a version-specific executor such as
-// [opensearchtools.osv2.Executor]. For example:
+// [opensearchtools/osv2.Executor]. For example:
 //
 //	mgetReq := NewMGetRequest().
 //		Add("example_index", "example_id")

--- a/osv2/executor.go
+++ b/osv2/executor.go
@@ -39,5 +39,5 @@ func (e *Executor) MGet(ctx context.Context, req *opensearchtools.MGetRequest) (
 		return nil, err
 	}
 
-	return osv2Resp.ToDomain(validationRes), err
+	return osv2Resp.toDomain(validationRes), err
 }

--- a/osv2/mget.go
+++ b/osv2/mget.go
@@ -153,12 +153,12 @@ type MGetResponse struct {
 	Docs       []MGetResult `json:"docs,omitempty"`
 }
 
-// ToDomain converts this instance of an [MGetResponse] along with the given [opensearchtools.ValidationResults]
+// toDomain converts this instance of an [MGetResponse] along with the given [opensearchtools.ValidationResults]
 // into an [opensearchtools.OpenSearchResponse[opensearchtools.MGetResponse]].
-func (r *MGetResponse) ToDomain(vrs opensearchtools.ValidationResults) *opensearchtools.OpenSearchResponse[opensearchtools.MGetResponse] {
+func (r *MGetResponse) toDomain(vrs opensearchtools.ValidationResults) *opensearchtools.OpenSearchResponse[opensearchtools.MGetResponse] {
 	modelDocs := make([]opensearchtools.MGetResult, len(r.Docs))
 	for i, d := range r.Docs {
-		modelDoc := d.ToDomain()
+		modelDoc := d.toDomain()
 		modelDocs[i] = modelDoc
 	}
 
@@ -188,8 +188,8 @@ type MGetResult struct {
 	Error       error           `json:"-"`
 }
 
-// ToDomain converts this instance of an [MGetResult] into an [opensearchtools.MGetResult].
-func (r *MGetResult) ToDomain() opensearchtools.MGetResult {
+// toDomain converts this instance of an [MGetResult] into an [opensearchtools.MGetResult].
+func (r *MGetResult) toDomain() opensearchtools.MGetResult {
 	return opensearchtools.MGetResult{
 		Index:       r.Index,
 		ID:          r.ID,

--- a/osv2/mget_test.go
+++ b/osv2/mget_test.go
@@ -141,7 +141,7 @@ func TestMGetRequest_MarshalJSON(t *testing.T) {
 	}
 }
 
-func Test_MGetResult_ToDomain(t *testing.T) {
+func Test_MGetResult_toDomain(t *testing.T) {
 	tests := []struct {
 		name              string
 		marshalableResult MGetResult
@@ -183,13 +183,13 @@ func Test_MGetResult_ToDomain(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.marshalableResult.ToDomain()
+			got := tt.marshalableResult.toDomain()
 			require.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func Test_MGetResponse_ToDomain(t *testing.T) {
+func Test_MGetResponse_toDomain(t *testing.T) {
 	testHeaders := http.Header{}
 	testHeaders.Add("x-foo", "bar")
 
@@ -298,7 +298,7 @@ func Test_MGetResponse_ToDomain(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.marshlableResponse.ToDomain(vrs)
+			got := tt.marshlableResponse.toDomain(vrs)
 			require.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
- un-export ToDomain methods
- use `/` for package separator in doc comment links