### PR TITLE
Add minimal Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: format
+format: 
+	@echo "Formatting..."
+	@gofmt -w -l -e .
+
+.PHONY: test
+test: 
+	@echo "Testing..."
+	@go test ./...
+
+.PHONY: help
+help:
+	@echo "make targets:"
+	@echo "format"
+	@echo "test"


### PR DESCRIPTION
Adds a minimal Makefile with `make format` and `make test`. 
I was going to add a `make lint` as well, but need to add this to our gomodguard config first.