### PR TITLE
Align executor patterns for mget and search

### DIFF
--- a/osv2/executor.go
+++ b/osv2/executor.go
@@ -58,13 +58,18 @@ func (e *Executor) Search(ctx context.Context, req *opensearchtools.SearchReques
 		return resp, err
 	}
 
+	validationRes := osv2Req.Validate()
+	if validationRes.IsFatal() {
+		return resp, opensearchtools.NewValidationError(validationRes)
+	}
+
 	osv2Resp, err := osv2Req.Do(ctx, e.Client)
 	if err != nil {
 		return resp, err
 	}
 
 	return opensearchtools.NewOpenSearchResponse(
-		osv2Resp.ValidationResults,
+		validationRes,
 		osv2Resp.StatusCode,
 		osv2Resp.Header,
 		osv2Resp.Response.ToDomain(),

--- a/osv2/executor.go
+++ b/osv2/executor.go
@@ -43,7 +43,7 @@ func (e *Executor) MGet(ctx context.Context, req *opensearchtools.MGetRequest) (
 		validationRes,
 		osv2Resp.StatusCode,
 		osv2Resp.Header,
-		osv2Resp.toDomain(),
+		osv2Resp.Response.toDomain(),
 	), nil
 }
 

--- a/osv2/mget.go
+++ b/osv2/mget.go
@@ -153,27 +153,17 @@ type MGetResponse struct {
 	Docs       []MGetResult `json:"docs,omitempty"`
 }
 
-// toDomain converts this instance of an [MGetResponse] along with the given [opensearchtools.ValidationResults]
-// into an [opensearchtools.OpenSearchResponse[opensearchtools.MGetResponse]].
-func (r *MGetResponse) toDomain(vrs opensearchtools.ValidationResults) *opensearchtools.OpenSearchResponse[opensearchtools.MGetResponse] {
+// toDomain converts this instance of an [MGetResponse] to an [opensearchtools.MGetResponse]
+func (r *MGetResponse) toDomain() opensearchtools.MGetResponse {
 	modelDocs := make([]opensearchtools.MGetResult, len(r.Docs))
 	for i, d := range r.Docs {
 		modelDoc := d.toDomain()
 		modelDocs[i] = modelDoc
 	}
 
-	domainMGetResponse := opensearchtools.MGetResponse{
+	return opensearchtools.MGetResponse{
 		Docs: modelDocs,
 	}
-
-	resp := opensearchtools.OpenSearchResponse[opensearchtools.MGetResponse]{
-		ValidationResults: vrs,
-		StatusCode:        r.StatusCode,
-		Header:            r.Header,
-		Response:          &domainMGetResponse,
-	}
-
-	return &resp
 }
 
 // mgetResult is the individual result for each requested item.

--- a/osv2/mget_test.go
+++ b/osv2/mget_test.go
@@ -194,13 +194,13 @@ func Test_MGetResponse_toDomain(t *testing.T) {
 	testHeaders.Add("x-foo", "bar")
 
 	tests := []struct {
-		name               string
-		marshlableResponse MGetResponse
-		want               *opensearchtools.OpenSearchResponse[opensearchtools.MGetResponse]
+		name             string
+		osv2MGetResponse MGetResponse
+		want             opensearchtools.MGetResponse
 	}{
 		{
 			name: "Multiple docs returned",
-			marshlableResponse: MGetResponse{
+			osv2MGetResponse: MGetResponse{
 				StatusCode: 200,
 				Header:     testHeaders,
 				Docs: []MGetResult{
@@ -236,69 +236,57 @@ func Test_MGetResponse_toDomain(t *testing.T) {
 					},
 				},
 			},
-			want: &opensearchtools.OpenSearchResponse[opensearchtools.MGetResponse]{
-				ValidationResults: nil,
-				StatusCode:        200,
-				Header:            testHeaders,
-				Response: &opensearchtools.MGetResponse{
-					Docs: []opensearchtools.MGetResult{
-						{
-							Index:       testIndex1,
-							ID:          testID1,
-							Version:     42,
-							SeqNo:       99,
-							PrimaryTerm: 10,
-							Found:       true,
-							Source:      []byte(`{"name": "bob", "age": 42}`),
-							Error:       nil,
-						},
-						{
-							Index:       testIndex2,
-							ID:          testID2,
-							Version:     1,
-							SeqNo:       2,
-							PrimaryTerm: 2,
-							Found:       true,
-							Source:      []byte(`{"deviceName": "abc123", "os": "windows"}`),
-							Error:       nil,
-						},
-						{
-							Index:       testIndex2,
-							ID:          testID2,
-							Version:     10,
-							SeqNo:       220,
-							PrimaryTerm: 30,
-							Found:       false,
-							Source:      []byte{},
-							Error:       nil,
-						},
+			want: opensearchtools.MGetResponse{
+				Docs: []opensearchtools.MGetResult{
+					{
+						Index:       testIndex1,
+						ID:          testID1,
+						Version:     42,
+						SeqNo:       99,
+						PrimaryTerm: 10,
+						Found:       true,
+						Source:      []byte(`{"name": "bob", "age": 42}`),
+						Error:       nil,
+					},
+					{
+						Index:       testIndex2,
+						ID:          testID2,
+						Version:     1,
+						SeqNo:       2,
+						PrimaryTerm: 2,
+						Found:       true,
+						Source:      []byte(`{"deviceName": "abc123", "os": "windows"}`),
+						Error:       nil,
+					},
+					{
+						Index:       testIndex2,
+						ID:          testID2,
+						Version:     10,
+						SeqNo:       220,
+						PrimaryTerm: 30,
+						Found:       false,
+						Source:      []byte{},
+						Error:       nil,
 					},
 				},
 			},
 		},
 		{
 			name: "No docs returned",
-			marshlableResponse: MGetResponse{
+			osv2MGetResponse: MGetResponse{
 				StatusCode: 200,
 				Header:     testHeaders,
 				Docs:       []MGetResult{},
 			},
-			want: &opensearchtools.OpenSearchResponse[opensearchtools.MGetResponse]{
-				ValidationResults: nil,
-				StatusCode:        200,
-				Header:            testHeaders,
-				Response: &opensearchtools.MGetResponse{
-					Docs: []opensearchtools.MGetResult{},
-				},
+			want: opensearchtools.MGetResponse{
+				Docs: []opensearchtools.MGetResult{},
 			},
 		},
 	}
 
-	var vrs opensearchtools.ValidationResults
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.marshlableResponse.toDomain(vrs)
+			got := tt.osv2MGetResponse.toDomain()
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/osv2/search.go
+++ b/osv2/search.go
@@ -127,6 +127,12 @@ func fromDomainSearchRequest(req *opensearchtools.SearchRequest) (sr SearchReque
 	}, nil
 }
 
+// Validate validates the given SearchRequest
+func (m *SearchRequest) Validate() opensearchtools.ValidationResults {
+	var validationResults opensearchtools.ValidationResults
+	return validationResults
+}
+
 // Do executes the SearchRequest using the provided [opensearch.Client].
 // If the request is executed successfully, then a SearchResponse will be returned.
 // An error can be returned if

--- a/osv2/search.go
+++ b/osv2/search.go
@@ -141,7 +141,7 @@ func (m *SearchRequest) Validate() opensearchtools.ValidationResults {
 //   - The source fails to be marshaled to JSON
 //   - The OpenSearch request fails to executed
 //   - The OpenSearch response cannot be parsed
-func (r *SearchRequest) Do(ctx context.Context, client *opensearch.Client) (*opensearchtools.OpenSearchResponse[SearchResponse], error) {
+func (r *SearchRequest) Do(ctx context.Context, client *opensearch.Client) (*opensearchtools.RawOpenSearchResponse[SearchResponse], error) {
 	bodyBytes, jErr := r.ToOpenSearchJSON()
 	if jErr != nil {
 		return nil, jErr
@@ -161,18 +161,17 @@ func (r *SearchRequest) Do(ctx context.Context, client *opensearch.Client) (*ope
 		return nil, err
 	}
 
-	var resp SearchResponse
-
-	if err := json.Unmarshal(respBuf.Bytes(), &resp); err != nil {
+	var searchResp SearchResponse
+	if err := json.Unmarshal(respBuf.Bytes(), &searchResp); err != nil {
 		return nil, err
 	}
 
-	return &opensearchtools.OpenSearchResponse[SearchResponse]{
-		ValidationResults: nil,
-		StatusCode:        osResp.StatusCode,
-		Header:            osResp.Header,
-		Response:          resp,
-	}, nil
+	resp := opensearchtools.NewRawOpenSearchResponse(
+		osResp.StatusCode,
+		osResp.Header,
+		searchResp,
+	)
+	return &resp, nil
 }
 
 // SearchResponse wraps the functionality of [opensearchapi.Response] by supporting request parsing.

--- a/osv2/search.go
+++ b/osv2/search.go
@@ -112,14 +112,14 @@ func (r *SearchRequest) WithQuery(q opensearchtools.Query) *SearchRequest {
 	return r
 }
 
-// fromDomainSearchRequest creates a new SearchRequest from the give [opensearchtools.SearchRequest]
-func fromDomainSearchRequest(req *opensearchtools.SearchRequest) (*SearchRequest, error) {
-	convertedQuery, queryErr := V2QueryConverter(req.Query)
-	if queryErr != nil {
-		return nil, queryErr
+// fromDomainSearchRequest creates a new SearchRequest from the given [opensearchtools.SearchRequest]
+func fromDomainSearchRequest(req *opensearchtools.SearchRequest) (sr SearchRequest, err error) {
+	convertedQuery, err := V2QueryConverter(req.Query)
+	if err != nil {
+		return sr, err
 	}
 
-	return &SearchRequest{
+	return SearchRequest{
 		Query: convertedQuery,
 		Index: req.Index,
 		Size:  req.Size,
@@ -165,7 +165,7 @@ func (r *SearchRequest) Do(ctx context.Context, client *opensearch.Client) (*ope
 		ValidationResults: nil,
 		StatusCode:        osResp.StatusCode,
 		Header:            osResp.Header,
-		Response:          &resp,
+		Response:          resp,
 	}, nil
 }
 

--- a/response.go
+++ b/response.go
@@ -2,20 +2,36 @@ package opensearchtools
 
 import "net/http"
 
+// RawOpenSearchResponse is a generic return type for an OpenSearch query which has meta fields common
+// to all response types as well as a generic Response field abstract across all response types.
+type RawOpenSearchResponse[T any] struct {
+	StatusCode int
+	Header     http.Header
+	Response   T
+}
+
+func NewRawOpenSearchResponse[T any](statusCode int, header http.Header, response T) RawOpenSearchResponse[T] {
+	return RawOpenSearchResponse[T]{
+		StatusCode: statusCode,
+		Header:     header,
+		Response:   response,
+	}
+}
+
 // OpenSearchResponse is a generic return type for an OpenSearch query which has meta fields common
 // to all response types as well as a generic Response field abstract across all response types.
 type OpenSearchResponse[T any] struct {
 	ValidationResults ValidationResults
-	StatusCode        int
-	Header            http.Header
-	Response          T
+	RawOpenSearchResponse[T]
 }
 
 func NewOpenSearchResponse[T any](vrs ValidationResults, statusCode int, header http.Header, response T) OpenSearchResponse[T] {
 	return OpenSearchResponse[T]{
 		ValidationResults: vrs,
-		StatusCode:        statusCode,
-		Header:            header,
-		Response:          response,
+		RawOpenSearchResponse: RawOpenSearchResponse[T]{
+			StatusCode: statusCode,
+			Header:     header,
+			Response:   response,
+		},
 	}
 }

--- a/response.go
+++ b/response.go
@@ -8,5 +8,14 @@ type OpenSearchResponse[T any] struct {
 	ValidationResults ValidationResults
 	StatusCode        int
 	Header            http.Header
-	Response          *T
+	Response          T
+}
+
+func NewOpenSearchResponse[T any](vrs ValidationResults, statusCode int, header http.Header, response T) OpenSearchResponse[T] {
+	return OpenSearchResponse[T]{
+		ValidationResults: vrs,
+		StatusCode:        statusCode,
+		Header:            header,
+		Response:          response,
+	}
 }


### PR DESCRIPTION
This PR aligns the executor patterns used in mget and search.

It also cleans up some value vs pointer stuff.