### PR TITLE
fix: updated and unified several patterns

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -9,7 +9,7 @@ import (
 //
 // [Bulk]: https://opensearch.org/docs/latest/api-reference/document-apis/bulk/
 type Bulk interface {
-	Bulk(ctx context.Context, req *BulkRequest) (*OpenSearchResponse[BulkResponse], error)
+	Bulk(ctx context.Context, req *BulkRequest) (OpenSearchResponse[BulkResponse], error)
 }
 
 // BulkRequest is a domain model union type for all the fields of BulkRequests for all

--- a/mget.go
+++ b/mget.go
@@ -10,7 +10,7 @@ import (
 //
 // [Multi-get]: https://opensearch.org/docs/latest/api-reference/document-apis/multi-get/
 type MGet interface {
-	MGet(ctx context.Context, req *MGetRequest) (*MGetResponse, error)
+	MGet(ctx context.Context, req *MGetRequest) (OpenSearchResponse[MGetResponse], error)
 }
 
 // MGetRequest is a domain model union type for all the fields of a Multi-Get request for all

--- a/osv2/bulk.go
+++ b/osv2/bulk.go
@@ -28,8 +28,8 @@ type BulkRequest struct {
 	Index string
 }
 
-// fromDomainBulkRequest creates a new [BulkRequest] from the given [opensearchtools.BulkRequest/.
-func fromDomainBulkRequest(req *opensearchtools.BulkRequest) (BulkRequest, opensearchtools.ValidationResults) {
+// FromDomainBulkRequest creates a new [BulkRequest] from the given [opensearchtools.BulkRequest/.
+func FromDomainBulkRequest(req *opensearchtools.BulkRequest) (BulkRequest, opensearchtools.ValidationResults) {
 	// As more versions are implemented, these [opensearchtools.ValidationResults] may be used to contain issues
 	// converting from the domain model to the V2 model.
 	var vrs opensearchtools.ValidationResults

--- a/osv2/executor.go
+++ b/osv2/executor.go
@@ -29,7 +29,7 @@ func NewExecutor(client *opensearch.Client) *Executor {
 //   - The request to OpenSearch fails
 //   - The results JSON cannot be unmarshalled
 func (e *Executor) MGet(ctx context.Context, req *opensearchtools.MGetRequest) (resp opensearchtools.OpenSearchResponse[opensearchtools.MGetResponse], err error) {
-	osv2Req, vrs := fromDomainMGetRequest(req)
+	osv2Req, vrs := FromDomainMGetRequest(req)
 	resp.ValidationResults.Extend(vrs)
 	if vrs.IsFatal() {
 		return resp, opensearchtools.NewValidationError(vrs)
@@ -55,7 +55,7 @@ func (e *Executor) MGet(ctx context.Context, req *opensearchtools.MGetRequest) (
 //   - The request to OpenSearch fails
 //   - The results JSON cannot be unmarshalled
 func (e *Executor) Search(ctx context.Context, req *opensearchtools.SearchRequest) (resp opensearchtools.OpenSearchResponse[opensearchtools.SearchResponse], err error) {
-	osv2Req, vrs := fromDomainSearchRequest(req)
+	osv2Req, vrs := FromDomainSearchRequest(req)
 	resp.ValidationResults.Extend(vrs)
 	if vrs.IsFatal() {
 		return resp, opensearchtools.NewValidationError(vrs)
@@ -81,7 +81,7 @@ func (e *Executor) Search(ctx context.Context, req *opensearchtools.SearchReques
 //   - The request to OpenSearch fails
 //   - The results json cannot be unmarshalled
 func (e *Executor) Bulk(ctx context.Context, req *opensearchtools.BulkRequest) (resp opensearchtools.OpenSearchResponse[opensearchtools.BulkResponse], err error) {
-	osv2Req, vrs := fromDomainBulkRequest(req)
+	osv2Req, vrs := FromDomainBulkRequest(req)
 	resp.ValidationResults.Extend(vrs)
 
 	if vrs.IsFatal() {

--- a/osv2/mget.go
+++ b/osv2/mget.go
@@ -101,8 +101,8 @@ func (m *MGetRequest) Do(ctx context.Context, client *opensearch.Client) (*opens
 	return &resp, nil
 }
 
-// fromDomainMGetRequest creates a new [MGetRequest] from the given [opensearchtools.MGetRequest].
-func fromDomainMGetRequest(req *opensearchtools.MGetRequest) (MGetRequest, opensearchtools.ValidationResults) {
+// FromDomainMGetRequest creates a new [MGetRequest] from the given [opensearchtools.MGetRequest].
+func FromDomainMGetRequest(req *opensearchtools.MGetRequest) (MGetRequest, opensearchtools.ValidationResults) {
 	return MGetRequest{
 		Index: req.Index,
 		Docs:  req.Docs,

--- a/osv2/search.go
+++ b/osv2/search.go
@@ -167,8 +167,8 @@ func (r *SearchRequest) WithRouting(routing ...string) *SearchRequest {
 	return r
 }
 
-// fromDomainSearchRequest creates a new SearchRequest from the given [opensearchtools.SearchRequest]
-func fromDomainSearchRequest(req *opensearchtools.SearchRequest) (SearchRequest, opensearchtools.ValidationResults) {
+// FromDomainSearchRequest creates a new SearchRequest from the given [opensearchtools.SearchRequest]
+func FromDomainSearchRequest(req *opensearchtools.SearchRequest) (SearchRequest, opensearchtools.ValidationResults) {
 	vrs := opensearchtools.NewValidationResults()
 	var (
 		searchRequest SearchRequest

--- a/search.go
+++ b/search.go
@@ -12,7 +12,7 @@ import (
 //
 // [Search]: https://opensearch.org/docs/latest/api-reference/search/
 type Search interface {
-	Search(ctx context.Context, req *SearchRequest) (OpenSearchResponse[*SearchResponse], error)
+	Search(ctx context.Context, req *SearchRequest) (OpenSearchResponse[SearchResponse], error)
 }
 
 // SearchRequest is a domain model union type for all the fields of a Search request across


### PR DESCRIPTION
Two main changes. First, exporting the `FromDomain*` translator methods converting Domain Models into Version specific models. Second change was updating the interface for Search, MGet, and Bulk to match our previous changes to the v2 executor.