### PR TITLE
feat(query): added support for nested query

### DIFF
--- a/search_query_nested.go
+++ b/search_query_nested.go
@@ -1,0 +1,56 @@
+package opensearchtools
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// NestedQuery is a type of joining query that allows searched in fields that are of the `nested` type.
+// An empty NestedQuery will be rejected by OpenSearch for two reasons:
+//
+//   - a path must not be nil or empty
+//   - a query must not be nil
+//
+// For more details see https://opensearch.org/docs/latest/query-dsl/
+type NestedQuery struct {
+	path  string
+	query Query
+}
+
+// NewNestedQuery initializes a NestedQuery targeting the nested field at the given path, with the provided query.
+func NewNestedQuery(path string, query Query) *NestedQuery {
+	return &NestedQuery{
+		path:  path,
+		query: query,
+	}
+}
+
+// ToOpenSearchJSON converts the Nested to the correct OpenSearch JSON.
+func (q *NestedQuery) ToOpenSearchJSON() ([]byte, error) {
+	var (
+		nestedQuery json.RawMessage
+		nestedErr   error
+	)
+
+	if q.path == "" {
+		return nil, fmt.Errorf("missing required nested path")
+	}
+
+	if q.query == nil {
+		return nil, fmt.Errorf("missing required nested query")
+	}
+
+	nestedQuery, nestedErr = q.query.ToOpenSearchJSON()
+	if nestedErr != nil {
+		return nil, nestedErr
+	}
+
+	source := map[string]any{
+		"nested": map[string]any{
+			"path":  q.path,
+			"query": nestedQuery,
+		},
+	}
+
+	return json.Marshal(source)
+}

--- a/search_query_nested_test.go
+++ b/search_query_nested_test.go
@@ -1,0 +1,50 @@
+package opensearchtools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNestedQuery_ToOpenSearchJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   *NestedQuery
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Empty Query",
+			query:   &NestedQuery{},
+			wantErr: true,
+		},
+		{
+			name:  "Simple Success",
+			query: NewNestedQuery("path", NewTermQuery("field", "value")),
+			want:  `{"nested":{"path":"path","query":{"term":{"field":"value"}}}}`,
+		},
+		{
+			name:    "Missing Path",
+			query:   NewNestedQuery("", NewTermQuery("field", "value")),
+			wantErr: true,
+		},
+		{
+			name:    "Missing Query",
+			query:   NewNestedQuery("path", nil),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.query.ToOpenSearchJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToOpenSearchJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if got != nil {
+				require.JSONEq(t, tt.want, string(got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds another query type, NestedQuery. Allowing you to target `nested` typed fields.