### PR TITLE
feat(bulk): addition of ParseResponseItemsOnlyOnFailure option for Bulk request to parse response only for errors

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -27,6 +27,9 @@ type BulkRequest struct {
 
 	// Index determines the entire index for the request
 	Index string
+
+	// ParseResponseItemsOnlyOnFailure determines if the bulk response is parsed all the time or only when errors present in the response
+	ParseResponseItemsOnlyOnFailure bool
 }
 
 // NewBulkRequest instantiates an empty BulkRequest


### PR DESCRIPTION
This PR add a small feature to unmarshall the bulk response only when there are errors. The idea is not to unmarshall 1000s of documents in the bulk response even when there are no errors.