### PR TITLE
Make the job in the deps check workflow not run for PRs from forks

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   snyk-test:
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Make the job in the deps check workflow not run for PRs from forks.

Without this change this workflow will fail because it relies on a token being injected and it won't be injected for PRs from forks