### PR TITLE
feat(search): added support for `from` on searches

### DIFF
--- a/osv2/search.go
+++ b/osv2/search.go
@@ -65,7 +65,7 @@ func V2AggregateConverter(agg opensearchtools.Aggregation) (opensearchtools.Aggr
 }
 
 // NewSearchRequest instantiates a SearchRequest with a From and Size of -1.
-// Any negative value for SearchRequest.From or SearchRequest.Size will be ignored and not included in the source.
+// Any negative value for [SearchRequest.From] or [SearchRequest.Size] will be ignored and not included in the source.
 // Opensearch by default, if no size is included in a search request, will limit the results to 10 documents.
 // Opensearch by default, if no from is included in a search request, will return hits starting from the first hit based on the sort.
 // A NewSearchRequest will search across all indices and return the top 10 documents with the default [sorting].

--- a/osv2/search.go
+++ b/osv2/search.go
@@ -31,6 +31,9 @@ type SearchRequest struct {
 	// Size of results to be returned
 	Size int
 
+	// From the starting index to search from
+	From int
+
 	// Sort(s) to order the results returned
 	Sort []opensearchtools.Sort
 
@@ -61,14 +64,15 @@ func V2AggregateConverter(agg opensearchtools.Aggregation) (opensearchtools.Aggr
 	return agg, nil
 }
 
-// NewSearchRequest instantiates a SearchRequest with a Size of -1.
-// Any negative value for SearchRequest.Size will be ignored and not included in the source.
+// NewSearchRequest instantiates a SearchRequest with a From and Size of -1.
+// Any negative value for SearchRequest.From or SearchRequest.Size will be ignored and not included in the source.
 // Opensearch by default, if no size is included in a search request, will limit the results to 10 documents.
+// Opensearch by default, if no from is included in a search request, will return hits starting from the first hit based on the sort.
 // A NewSearchRequest will search across all indices and return the top 10 documents with the default [sorting].
 //
 // [sorting]: https://openopensearchtools.org/docs/latest/opensearch/search/sort/
 func NewSearchRequest() *SearchRequest {
-	return &SearchRequest{Size: -1}
+	return &SearchRequest{Size: -1, From: -1}
 }
 
 // ToOpenSearchJSON marshals the SearchRequest into the JSON shape expected by OpenSearch.
@@ -85,6 +89,10 @@ func (r *SearchRequest) ToOpenSearchJSON() ([]byte, error) {
 
 	if r.Size >= 0 {
 		source["size"] = r.Size
+	}
+
+	if r.From >= 0 {
+		source["from"] = r.From
 	}
 
 	if len(r.Sort) > 0 {
@@ -139,6 +147,13 @@ func (r *SearchRequest) AddIndices(indices ...string) *SearchRequest {
 // A negative value for size will be ignored and not included in the SearchRequest.Source.
 func (r *SearchRequest) WithSize(n int) *SearchRequest {
 	r.Size = n
+	return r
+}
+
+// WithFrom sets the request's starting index for the result hits.
+// A negative value for from will be ignored and not included in the SearchRequest.Source.
+func (r *SearchRequest) WithFrom(n int) *SearchRequest {
+	r.From = n
 	return r
 }
 
@@ -200,6 +215,7 @@ func FromDomainSearchRequest(req *opensearchtools.SearchRequest) (SearchRequest,
 
 	searchRequest.Index = req.Index
 	searchRequest.Size = req.Size
+	searchRequest.From = req.From
 	searchRequest.Sort = req.Sort
 	searchRequest.Query = query
 	searchRequest.Aggregations = aggs

--- a/osv2/search_test.go
+++ b/osv2/search_test.go
@@ -28,8 +28,9 @@ func TestSearchRequest_ToOpenSearchJSON(t *testing.T) {
 				WithQuery(opensearchtools.NewTermQuery("field", "value")).
 				AddIndices("test_index").
 				AddSorts(opensearchtools.NewSort("field", true)).
-				WithSize(1),
-			want:    `{"query":{"term":{"field":"value"}},"sort":[{"field":{"order":"desc"}}],"size":1}`,
+				WithSize(1).
+				WithFrom(1),
+			want:    `{"query":{"term":{"field":"value"}},"sort":[{"field":{"order":"desc"}}],"size":1,"from":1}`,
 			wantErr: false,
 		},
 		{
@@ -65,6 +66,20 @@ func TestSearchRequest_ToOpenSearchJSON(t *testing.T) {
 			search: NewSearchRequest().
 				WithSize(1),
 			want:    `{"size":1}`,
+			wantErr: false,
+		},
+		{
+			name: "Set From",
+			search: NewSearchRequest().
+				WithFrom(1),
+			want:    `{"from":1}`,
+			wantErr: false,
+		},
+		{
+			name: "Negative From is ignored",
+			search: NewSearchRequest().
+				WithFrom(-5),
+			want:    `{}`,
 			wantErr: false,
 		},
 		{

--- a/search.go
+++ b/search.go
@@ -40,6 +40,9 @@ type SearchRequest struct {
 	// Size of results to be returned
 	Size int
 
+	// From the starting index to search from
+	From int
+
 	// Sort(s) to order the results returned
 	Sort []Sort
 
@@ -53,14 +56,15 @@ type SearchRequest struct {
 	Aggregations map[string]Aggregation
 }
 
-// NewSearchRequest instantiates a SearchRequest with a Size of -1.
-// Any negative value for SearchRequest.Size will be ignored and not included in the source.
+// NewSearchRequest instantiates a SearchRequest with a From and Size of -1.
+// Any negative value for SearchRequest.From or SearchRequest.Size will be ignored and not included in the source.
 // Opensearch by default, if no size is included in a search request, will limit the results to 10 documents.
+// Opensearch by default, if no from is included in a search request, will return hits starting from the first hit based on the sort.
 // A NewSearchRequest will search across all indices and return the top 10 documents with the default [sorting].
 //
 // [sorting]: https://openorg/docs/latest/opensearch/search/sort/
 func NewSearchRequest() *SearchRequest {
-	return &SearchRequest{Size: -1}
+	return &SearchRequest{Size: -1, From: -1}
 }
 
 // AddIndices sets the index list for the request.
@@ -73,6 +77,13 @@ func (r *SearchRequest) AddIndices(indices ...string) *SearchRequest {
 // A negative value for size will be ignored and not included in the SearchRequest.Source.
 func (r *SearchRequest) WithSize(n int) *SearchRequest {
 	r.Size = n
+	return r
+}
+
+// WithFrom sets the request's starting index for the result hits.
+// A negative value for from will be ignored and not included in the SearchRequest.Source.
+func (r *SearchRequest) WithFrom(n int) *SearchRequest {
+	r.From = n
 	return r
 }
 


### PR DESCRIPTION
The from field allows the consumer to set what index the results should start from. 

Similar to the Size field, if a negative number is used, it will be omitted in favor of OpenSearch's default of 0.