### PR TITLE
feat(query): add support for term query by ids

### DIFF
--- a/search_query_ids.go
+++ b/search_query_ids.go
@@ -1,0 +1,31 @@
+package opensearchtools
+
+import "encoding/json"
+
+// IDsQuery finds documents that have the id match one of the listed values.
+// An empty IDsQuery will be rejected by OpenSearch for the following reasons:
+//
+//   - a value must be non-null
+//
+// For more details see https://opensearch.org/docs/latest/query-dsl/term/#ids
+type IDsQuery struct {
+	values []any
+}
+
+// NewIDsQuery instantiates a IDsQuery looking for one of the id values.
+func NewIDsQuery(values ...any) *IDsQuery {
+	return &IDsQuery{
+		values: values,
+	}
+}
+
+// ToOpenSearchJSON converts the IDsQuery to the correct OpenSearch JSON.
+func (q *IDsQuery) ToOpenSearchJSON() ([]byte, error) {
+	source := map[string]any{
+		"ids": map[string]any{
+			"values": q.values,
+		},
+	}
+
+	return json.Marshal(source)
+}

--- a/search_query_ids_test.go
+++ b/search_query_ids_test.go
@@ -1,0 +1,59 @@
+package opensearchtools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIDsQuery_ToOpenSearchJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   *IDsQuery
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Empty query",
+			query:   &IDsQuery{},
+			want:    `{"ids":{"values":null}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Basic Constructor",
+			query:   NewIDsQuery(),
+			want:    `{"ids":{"values":null}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Single value",
+			query:   NewIDsQuery("value1"),
+			want:    `{"ids":{"values":["value1"]}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Multiple Values",
+			query:   NewIDsQuery("value1", "value2", "value3"),
+			want:    `{"ids":{"values":["value1","value2","value3"]}}`,
+			wantErr: false,
+		},
+		{
+			name:    "Mixed type values",
+			query:   NewIDsQuery("value1", 2),
+			want:    `{"ids":{"values":["value1",2]}}`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.query.ToOpenSearchJSON()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToOpenSearchJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			require.JSONEq(t, tt.want, string(got))
+		})
+	}
+}


### PR DESCRIPTION
Adds support for term level queries using IDs to search for one or more document ID values.

Ref.: https://opensearch.org/docs/latest/query-dsl/term/#ids